### PR TITLE
fn: Add support for Intel disassembly syntax

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -154,6 +154,15 @@ pub struct SectionArgs {
     pub skip: Option<usize>,
 }
 
+#[derive(Clone, Copy, ValueEnum, Debug, Default)]
+pub enum Syntax {
+    /// GNU assembler (AT&T)
+    #[default]
+    Att,
+    /// Intel
+    Intel,
+}
+
 #[derive(Args, Debug)]
 pub struct FnArgs {
     #[arg()]
@@ -167,6 +176,10 @@ pub struct FnArgs {
     /// Superimpose call-frame information extracted from `.eh_frame`.
     #[arg(long)]
     pub cfi: bool,
+
+    /// Syntax to use to format the disassembly.
+    #[arg(long, value_enum, default_value_t = Syntax::Att)]
+    pub syntax: Syntax,
 }
 
 #[derive(Args, Debug, Clone, Default)]


### PR DESCRIPTION
Adds the --syntax option which can be used to format the disassembly with Intel syntax, for people who prefer that option.